### PR TITLE
added python3 compatibility

### DIFF
--- a/colorterm/table.py
+++ b/colorterm/table.py
@@ -120,4 +120,4 @@ if __name__ == '__main__':
         }
         t.add_row(dic)
 
-    print t.display()
+    print(t.display())


### PR DESCRIPTION
Just fixed print() function call to make 'colorterm' compatible with python3.